### PR TITLE
🔒 Run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ COPY requirements.txt ./
 # Install dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Create non-root user
+RUN useradd -m -u 1000 ryan
+
 # Remove build dependencies to reduce image size
 RUN apt-get remove -y build-essential && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
@@ -29,5 +32,12 @@ RUN chmod +x /entrypoint.sh
 COPY nginx.conf /etc/nginx/sites-available/default
 RUN ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
 
-EXPOSE 80
+# Drop the "user" directive (only valid when nginx runs as root) and give the
+# non-root user ownership of every path nginx and the build step write to
+RUN sed -i '/^user /d' /etc/nginx/nginx.conf && \
+    chown -R ryan:ryan /app /usr/share/nginx/html /var/log/nginx /var/lib/nginx
+
+USER ryan
+
+EXPOSE 8080
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,10 @@ RUN chmod +x /entrypoint.sh
 COPY nginx.conf /etc/nginx/sites-available/default
 RUN ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
 
-# Drop the "user" directive (only valid when nginx runs as root) and give the
-# non-root user ownership of every path nginx and the build step write to
-RUN sed -i '/^user /d' /etc/nginx/nginx.conf && \
+# Drop the "user" directive (only valid when nginx runs as root), move the PID
+# file to a path the non-root user can write, and give that user ownership of
+# every path nginx and the build step write to
+RUN sed -i -e '/^user /d' -e 's#/run/nginx.pid#/tmp/nginx.pid#' /etc/nginx/nginx.conf && \
     chown -R ryan:ryan /app /usr/share/nginx/html /var/log/nginx /var/lib/nginx
 
 USER ryan

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ pelican content -s publishconf.py -e SITEURL='"'${SITEURL}'"'
 # Copy generated files to nginx html directory
 cp -r output/* /usr/share/nginx/html/
 
-echo "Starting nginx server on port 80"
+echo "Starting nginx server on port 8080"
 
-# Start nginx in foreground (pid in /tmp so the non-root user can write it)
-exec nginx -g 'pid /tmp/nginx.pid; daemon off;'
+# Start nginx in foreground
+exec nginx -g 'daemon off;'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,5 +14,5 @@ cp -r output/* /usr/share/nginx/html/
 
 echo "Starting nginx server on port 80"
 
-# Start nginx in foreground
-exec nginx -g 'daemon off;'
+# Start nginx in foreground (pid in /tmp so the non-root user can write it)
+exec nginx -g 'pid /tmp/nginx.pid; daemon off;'

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,6 @@
 server {
-    listen       80;
-    listen  [::]:80;
+    listen       8080;
+    listen  [::]:8080;
     server_name  localhost;
 
     root   /usr/share/nginx/html;


### PR DESCRIPTION
## Summary

Hardens the Docker image by running nginx as the unprivileged `ryan` user instead of root.

## Changes

- **Dockerfile**
  - Add `USER ryan` so the container process runs unprivileged
  - `chown` every path the process writes to: the html root (`/usr/share/nginx/html`), nginx's `/var/log/nginx` and `/var/lib/nginx`, and `/app`
  - Strip the `user` directive from `/etc/nginx/nginx.conf`, which is only valid when nginx runs as root
  - `EXPOSE 8080`
- **nginx.conf** — listen on `8080` instead of `80`, since non-root processes cannot bind to ports below 1024
- **entrypoint.sh** — write the PID file to `/tmp/nginx.pid` so `ryan` can create it

## Deployment note

The container now listens on **8080**. Update Coolify's **Ports Exposes** to `8080` (and the health-check port if configured) before/with deploying. The public domain and SSL are unaffected — Traefik terminates TLS and proxies to the internal port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)