### PR TITLE
🎨 Style datasette search pages to match the blog theme

### DIFF
--- a/datasette-custom.css
+++ b/datasette-custom.css
@@ -1,0 +1,72 @@
+/* Datasette theme to match the pelican-clean-blog blog at ryancheley.com */
+
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&family=Lora:ital@0;1&display=swap');
+
+:root {
+  --accent: #0085a1;
+  --accent-dark: #006a80;
+  --ink: #404040;
+}
+
+body {
+  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  color: var(--ink);
+}
+
+/* Headings use Lora, like the blog */
+h1, h2, h3,
+.page-header h1 {
+  font-family: 'Lora', 'Times New Roman', serif;
+}
+
+/* Datasette's top nav bar -> dark, like the blog nav/footer */
+header.hd,
+.hd {
+  background-color: var(--ink);
+}
+
+header.hd a,
+.hd a {
+  color: #fff;
+}
+
+/* Links and accent teal */
+a {
+  color: var(--accent);
+}
+
+a:hover {
+  color: var(--accent-dark);
+}
+
+/* Buttons (search / "Run SQL" / apply) */
+.core button,
+button[type=submit],
+input[type=submit],
+.dt-button {
+  background-color: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.core button:hover,
+button[type=submit]:hover,
+input[type=submit]:hover {
+  background-color: var(--accent-dark);
+  border-color: var(--accent-dark);
+}
+
+/* Search and filter inputs */
+input[type=search],
+input[type=text],
+textarea {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 6px 8px;
+}
+
+/* Table header row */
+table.rows-and-columns thead th {
+  background-color: #f2f2f2;
+  border-bottom: 2px solid var(--accent);
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,4 +1,7 @@
 {
+    "extra_css_urls": [
+        "https://cdn.jsdelivr.net/gh/ryancheley/ryancheley.com@main/datasette-custom.css"
+    ],
     "databases": {
         "pelican": {
             "queries": {


### PR DESCRIPTION
## What

Styles the datasette search/database pages to match the **pelican-clean-blog** theme used at ryancheley.com.

- Adds `datasette-custom.css` mapping the blog's visual signature onto datasette:
  - Body font: `Open Sans`
  - Heading font: `Lora`
  - Accent/link color: `#0085a1`
  - Dark nav bar: `#404040`
- References it from `metadata.json` via top-level `extra_css_urls`, served through the **jsDelivr** CDN (`cdn.jsdelivr.net/gh/...`) so the file is delivered with the correct `text/css` MIME type.

## Why jsDelivr instead of raw.githubusercontent.com

`raw.githubusercontent.com` serves CSS as `text/plain` with `X-Content-Type-Options: nosniff`, which browsers refuse to apply as a stylesheet. jsDelivr serves the same repo file as `text/css`.

## Deployment notes

- **No Coolify Dockerfile change required** — the embedded Dockerfile already `curl`s `metadata.json` fresh on each rebuild, so a redeploy picks up the new `extra_css_urls`.
- jsDelivr caches branch URLs (`@main`) for up to ~12h. To force a refresh after changing the CSS, purge via `https://purge.jsdelivr.net/gh/ryancheley/ryancheley.com@main/datasette-custom.css`, or pin a commit/tag in the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)