### PR TITLE
✨ Add blog-style hero masthead to datasette pages

### DIFF
--- a/datasette-custom.css
+++ b/datasette-custom.css
@@ -88,3 +88,41 @@ table.rows-and-columns thead th {
   background-color: #f2f2f2;
   border-bottom: 2px solid var(--accent);
 }
+
+/* Blog-style hero masthead (paired with datasette-templates/base.html) */
+.masthead {
+  background-color: #808080; /* fallback before image loads */
+  background-image: url('https://www.ryancheley.com/theme/images/home-bg.jpg');
+  background-position: center center;
+  background-size: cover;
+  background-repeat: no-repeat;
+  margin-bottom: 2rem;
+  color: #fff;
+}
+
+.masthead-inner {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 120px 1rem 90px;
+  text-align: center;
+}
+
+.masthead h1 {
+  margin: 0;
+  font-family: 'Lora', 'Times New Roman', serif;
+  font-size: 50px;
+}
+
+.masthead h1 a:link,
+.masthead h1 a:visited,
+.masthead h1 a:hover {
+  color: #fff;
+  text-decoration: none;
+}
+
+.masthead-subheading {
+  margin: 10px 0 0;
+  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-weight: 300;
+  font-size: 24px;
+}

--- a/datasette-templates/base.html
+++ b/datasette-templates/base.html
@@ -1,0 +1,11 @@
+{% extends "default:base.html" %}
+
+{% block messages %}
+  <div class="masthead" role="banner">
+    <div class="masthead-inner">
+      <h1><a href="/">RyanCheley.com</a></h1>
+      <p class="masthead-subheading">My Place on the Internet</p>
+    </div>
+  </div>
+  {{ super() }}
+{% endblock %}


### PR DESCRIPTION
## What

Adds a blog-style hero masthead to the datasette search/database pages so they match the ryancheley.com **pelican-clean-blog** masthead (the `.intro-header` hero with the site title + subtitle over `home-bg.jpg`).

- **`datasette-templates/base.html`** (new) — a ~12-line template that `{% extends "default:base.html" %}` and injects the masthead into the `messages` block, calling `{{ super() }}` so datasette's real message rendering is preserved. No need to fork datasette's full `base.html`, so this stays low-maintenance across datasette upgrades.
- **`datasette-custom.css`** — adds `.masthead` styles mirroring the blog's `.intro-header`: `home-bg.jpg` cover background (gray fallback), `Lora` title at 50px, `Open Sans` 300 subheading at 24px, white text.

## Deployment (Coolify)

The template is read from disk by datasette, so it must be `curl`ed into the image and exposed via `--template-dir`. Add to the embedded Coolify Dockerfile:

```dockerfile
ARG TEMPLATE_URL=https://raw.githubusercontent.com/ryancheley/ryancheley.com/refs/heads/main/datasette-templates/base.html

RUN mkdir -p /data/templates
RUN curl -L -o /data/templates/base.html ${TEMPLATE_URL}
```
(place before `chown -R appuser:appuser /data`), and append `"--template-dir", "/data/templates"` to the `CMD`.

After merge:
1. **Rebuild** the Coolify container (template is baked in at build time — a plain redeploy won't pick it up).
2. Purge the jsDelivr CSS cache for the new `.masthead` rules: `https://purge.jsdelivr.net/gh/ryancheley/ryancheley.com@main/datasette-custom.css`

## Caveat

The `{% extends "default:base.html" %}` + `messages` block approach relies on that block existing in the installed datasette (it does in current releases). If the deployed image runs an older datasette and the masthead doesn't appear, the fallback is copying datasette's full `base.html` into the template and inserting the masthead `<div>` after `</header>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)